### PR TITLE
Jcp add partial board deployment

### DIFF
--- a/looker_deployer/cli.py
+++ b/looker_deployer/cli.py
@@ -33,7 +33,11 @@ def setup_board_subparser(subparsers):
     boards_subparser.add_argument("--target", required=True, nargs="+", help="which target environment(s) to deploy to")
     boards_subparser.add_argument("--board", required=True, help="which board to deploy")
     boards_subparser.add_argument("--ini", default=loc, help="ini file to parse for credentials")
-
+    boards_subparser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="allow partial deployment of board content if not all content is present on target instance?"
+    )
     boards_subparser.add_argument(
         "--title-change",
         help="if updating title, the old title to replace in target environments"

--- a/looker_deployer/commands/deploy_boards.py
+++ b/looker_deployer/commands/deploy_boards.py
@@ -66,7 +66,10 @@ def match_look_id(source_look_id, source_sdk, target_sdk):
 def return_board(board_name, source_sdk):
     logger.debug("Searching boards", extra={"title": board_name})
     board_list = source_sdk.search_homepages(title=board_name)
-    assert len(board_list) < 2, "More than one board found! Refine your search or remove duplicate names."
+
+    if len(board_list) > 1:
+        raise MultipleAssetsFoundError(board_name)
+
     assert len(board_list) == 1, "Could not find board! Double check available titles and try again."
 
     logger.debug("Found board", extra={"board": board_list})
@@ -229,7 +232,7 @@ def send_boards(board_name, source_sdk, target_sdk, title_override=None, allow_p
                 create_board_item(item, target_section_id, source_sdk, target_sdk)
             except AssertionError:
                 if allow_partial:
-                    logger.warning("Could not find content!", extra={"item": item})
+                    logger.warning("Could not find content!", extra={"item": item.title})
                     pass
                 else:
                     raise

--- a/tests/test_deploy_boards.py
+++ b/tests/test_deploy_boards.py
@@ -59,7 +59,7 @@ def test_match_dashboard_id_multi(mocker):
     mocker.patch.object(sdk, "search_dashboards")
     sdk.search_dashboards.return_value = [dash, dash]
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(deploy_boards.MultipleAssetsFoundError):
         deploy_boards.match_dashboard_id(1, sdk, sdk)
 
 
@@ -81,7 +81,7 @@ def test_match_look_id_multi(mocker):
     mocker.patch.object(sdk, "search_looks")
     sdk.search_looks.return_value = [look, look]
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(deploy_boards.MultipleAssetsFoundError):
         deploy_boards.match_look_id(1, sdk, sdk)
 
 

--- a/tests/test_deploy_boards.py
+++ b/tests/test_deploy_boards.py
@@ -25,10 +25,13 @@ class MockDash:
 
 class MockHomepageItem:
     id = 5
+    dashboard_id = 2
+    look_id = 1
 
 
 class MockHomepageSection:
     id = 4
+    homepage_items = [MockHomepageItem()]
 
 
 sdk = methods.LookerSDK(mockAuth(), "bar", "baz", "bosh", "bizz")
@@ -96,7 +99,7 @@ def test_return_board_multi(mocker):
     mocker.patch.object(sdk, "search_homepages")
     sdk.search_homepages.return_value = [42, 81]
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(deploy_boards.MultipleAssetsFoundError):
         deploy_boards.return_board("foo", sdk)
 
 
@@ -252,3 +255,23 @@ def test_create_board_item_look_item_call(mocker):
             homepage_section_id=10
         )
     )
+
+
+def test_audit_board_with_misses(mocker):
+    test_board = MockHomepage()
+    mocker.patch("looker_deployer.commands.deploy_boards.match_dashboard_id", side_effect=AssertionError)
+    mocker.patch("looker_deployer.commands.deploy_boards.match_look_id", side_effect=AssertionError)
+    mocker.patch.object(sdk, "dashboard")
+    mocker.patch.object(sdk, "look")
+    sdk.dashboard.return_value = MockDash()
+    sdk.look.return_value = MockLook()
+    missing = deploy_boards.audit_board_content(test_board, sdk, sdk)
+    assert missing == ([{"dash_id": 2, "dash_title": "foobarbaz"}], [{"look_id": 1, "look_title": "foobarbaz"}])
+
+
+def test_audit_board_no_misses(mocker):
+    test_board = MockHomepage()
+    mocker.patch("looker_deployer.commands.deploy_boards.match_dashboard_id")
+    mocker.patch("looker_deployer.commands.deploy_boards.match_look_id")
+    missing = deploy_boards.audit_board_content(test_board, sdk, sdk)
+    assert missing == ([], [])


### PR DESCRIPTION
This addresses a request to allow for board deployment to proceed even if all the content is not present. At the same time I've improved the content auditing to return all missing content at once rather than potentially in a chain of individual errors.