### PR TITLE
if windows environment then call command line parser directly

### DIFF
--- a/looker_deployer/commands/deploy_content.py
+++ b/looker_deployer/commands/deploy_content.py
@@ -82,6 +82,11 @@ def export_spaces(env, ini, path, debug=False):
     if debug:
         gzr_command.append("--debug")
 
+    # if we're running on windows we need to appropriately call the command-line arg"
+    if os.name == "nt":
+        win_exec = ["cmd.exe", "/c"]
+        gzr_command = win_exec + gzr_command
+
     subprocess.run(gzr_command)
 
 
@@ -124,6 +129,11 @@ def import_content(content_type, content_json, space_id, env, ini, debug=False):
         gzr_command.append("--no-verify-ssl")
     if debug:
         gzr_command.append("--debug")
+
+    # if we're running on windows we need to appropriately call the command-line arg"
+    if os.name == "nt":
+        win_exec = ["cmd.exe", "/c"]
+        gzr_command = win_exec + gzr_command
 
     subprocess.run(gzr_command)
 

--- a/tests/test_deploy_content.py
+++ b/tests/test_deploy_content.py
@@ -160,6 +160,34 @@ def test_export_space_no_verify_ssl(mocker):
     ])
 
 
+def test_export_space_win(mocker):
+    mocker.patch("looker_deployer.commands.deploy_content.get_gzr_creds")
+    deploy_content.get_gzr_creds.return_value = ("foobar.com", "1234", "abc", "xyz", "True")
+
+    mocker.patch("os.name", "nt")
+
+    mocker.patch("subprocess.run")
+    deploy_content.export_spaces("env", "ini", "foo/bar", False)
+    subprocess.run.assert_called_with([
+        "cmd.exe",
+        "/c",
+        "gzr",
+        "space",
+        "export",
+        "1",
+        "--dir",
+        "foo/bar",
+        "--host",
+        "foobar.com",
+        "--port",
+        "1234",
+        "--client-id",
+        "abc",
+        "--client-secret",
+        "xyz"
+    ])
+
+
 def test_import_content(mocker):
     mocker.patch("looker_deployer.commands.deploy_content.get_gzr_creds")
     deploy_content.get_gzr_creds.return_value = ("foobar.com", "1234", "abc", "xyz", "True")
@@ -231,6 +259,34 @@ def test_import_content_no_verify_ssl(mocker):
         "xyz",
         "--force",
         "--no-verify-ssl"
+    ])
+
+
+def test_import_content_win(mocker):
+    mocker.patch("looker_deployer.commands.deploy_content.get_gzr_creds")
+    deploy_content.get_gzr_creds.return_value = ("foobar.com", "1234", "abc", "xyz", "True")
+
+    mocker.patch("os.name", "nt")
+
+    mocker.patch("subprocess.run")
+    deploy_content.import_content("dashboard", "tacocat.json", "42", "env", "ini", False)
+    subprocess.run.assert_called_with([
+        "cmd.exe",
+        "/c",
+        "gzr",
+        "dashboard",
+        "import",
+        "tacocat.json",
+        "42",
+        "--host",
+        "foobar.com",
+        "--port",
+        "1234",
+        "--client-id",
+        "abc",
+        "--client-secret",
+        "xyz",
+        "--force"
     ])
 
 


### PR DESCRIPTION
without this the tool throws a "file not found" error on windows. We have to specify that gzr needs to be run by the cmd.exe for windows. 

os.name will return 'nt' for any windows device

Tested on a Windows Server Datacenter 2019 VM on GCP and confirmed to work on there.